### PR TITLE
[ENGINE-978] Change revision scheme per ENGINE-970 requirements

### DIFF
--- a/hack/build
+++ b/hack/build
@@ -6,12 +6,16 @@ set -e
 : "${PACKAGE=github.com/docker/buildx}"
 : "${VERSION=$(./hack/git-meta version)}"
 : "${REVISION=$(./hack/git-meta revision)}"
+: "${PRERELEASE=$(./hack/git-meta version | rev | cut -c3- | rev | cut -d'-' -f 2 | grep -E '(^tp|^rc).*')}"
+: "${REVISION_NUMBER=1}"
+VERSION=$(printf "v%sm%s%s" "$(./hack/git-meta version | rev | cut -c3- | rev | cut -d'-' -f 1 | cut -c2-)" "${REVISION_NUMBER}" "-${PRERELEASE}")
 
 : "${CGO_ENABLED=0}"
 : "${GO_PKG=github.com/docker/buildx}"
 : "${GO_EXTRA_FLAGS=}"
 : "${GO_LDFLAGS=-X ${GO_PKG}/version.Version=${VERSION} -X ${GO_PKG}/version.Revision=${REVISION} -X ${GO_PKG}/version.Package=${PACKAGE}}"
 : "${GO_EXTRA_LDFLAGS=}"
+
 
 set -x
 CGO_ENABLED=$CGO_ENABLED go build -mod vendor -trimpath ${GO_EXTRA_FLAGS} -ldflags "${GO_LDFLAGS} ${GO_EXTRA_LDFLAGS}" -o "${DESTDIR}/docker-buildx" ./cmd/buildx

--- a/hack/build
+++ b/hack/build
@@ -8,7 +8,12 @@ set -e
 : "${REVISION=$(./hack/git-meta revision)}"
 : "${PRERELEASE=$(./hack/git-meta version | rev | cut -c3- | rev | cut -d'-' -f 2 | grep -E '(^tp|^rc).*')}"
 : "${REVISION_NUMBER=1}"
-VERSION=$(printf "v%sm%s%s" "$(./hack/git-meta version | rev | cut -c3- | rev | cut -d'-' -f 1 | cut -c2-)" "${REVISION_NUMBER}" "-${PRERELEASE}")
+
+if [ -n "$PRERELEASE" ]; then
+  PRERELEASE="-$PRERELEASE"
+fi
+
+VERSION=$(printf "v%sm%s%s" "$(./hack/git-meta version | rev | cut -c3- | rev | cut -d'-' -f 1 | cut -c2-)" "${REVISION_NUMBER}" "${PRERELEASE}")
 
 : "${CGO_ENABLED=0}"
 : "${GO_PKG=github.com/docker/buildx}"

--- a/tests/version.go
+++ b/tests/version.go
@@ -1,13 +1,13 @@
 package tests
 
 import (
+	"regexp"
 	"strings"
 	"testing"
 
 	"github.com/moby/buildkit/util/testutil/integration"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/mod/module"
-	"golang.org/x/mod/semver"
 )
 
 var versionTests = []func(t *testing.T, sb integration.Sandbox){
@@ -45,7 +45,8 @@ func testVersion(t *testing.T, sb integration.Sandbox) {
 	// This defaults to something that's still compatible
 	// with semver.
 	version := fields[1]
-	require.True(t, semver.IsValid(version), "Second field was not valid semver: %+v", version)
+	regex, err := regexp.CompilePOSIX("^v[0-9]+.[0-9]+.[0-9]+(m[0-9]+|m[0-9]+-rc[0-9]+|m[0-9]+-tp[0-9]+)$")
+	require.True(t, err == nil && regex.MatchString(version), "Second field was not valid: %+v", version)
 
 	// Revision should be empty or should look like a git hash.
 	if len(fields) > 2 && len(fields[2]) > 0 {

--- a/tests/version.go
+++ b/tests/version.go
@@ -45,8 +45,8 @@ func testVersion(t *testing.T, sb integration.Sandbox) {
 	// This defaults to something that's still compatible
 	// with semver.
 	version := fields[1]
-	regex, err := regexp.CompilePOSIX("^v[0-9]+.[0-9]+.[0-9]+(m[0-9]+|m[0-9]+-rc[0-9]+|m[0-9]+-tp[0-9]+)$")
-	require.True(t, err == nil && regex.MatchString(version), "Second field was not valid: %+v", version)
+	regex := regexp.MustCompilePOSIX("^v[0-9]+.[0-9]+.[0-9]+(m[0-9]+|m[0-9]+-rc[0-9]+|m[0-9]+-tp[0-9]+)$")
+	require.True(t, regex.MatchString(version), "Second field was not valid: %+v", version)
 
 	// Revision should be empty or should look like a git hash.
 	if len(fields) > 2 && len(fields[2]) > 0 {


### PR DESCRIPTION
This is a PR in order to change the versioning scheme to utilize the upstream buildx version along with the PRERELEASE and REVISIONS schemes described in ENGINE-970.